### PR TITLE
feat: use pnpm 7.15.0 via corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,5 +108,6 @@
     "node": "^14.13.1 || >=16.0.0",
     "yarn": ">=1.22.0",
     "npm": "please-use-yarn"
-  }
+  },
+  "packageManager": "pnpm@7.15.0"
 }


### PR DESCRIPTION
Trying to debug https://github.com/vercel/next.js/issues/42641 with the same version of pnpm (experimental corepack)