### PR TITLE
Compare and benchmark yarn.enableMirror impact

### DIFF
--- a/.github/actions/yarn-nm-install/action.yml
+++ b/.github/actions/yarn-nm-install/action.yml
@@ -18,6 +18,7 @@
 #   - latest: https://gist.github.com/belgattitude/042f9caf10d029badbde6cf9d43e400a    #
 #                                                                                      #
 # Versions:                                                                            #
+#   - 1.0.3 - 05-07-2023 - YARN_ENABLE_MIRROR to false (speed up cold start)           #
 #   - 1.0.2 - 02-06-2023 - install-state default to false                              #
 #   - 1.0.1 - 29-05-2023 - cache-prefix doc                                            #
 #   - 1.0.0 - 27-05-2023 - new input: cache-prefix                                     #
@@ -99,9 +100,9 @@ runs:
       run: yarn install --immutable --inline-builds
       env:
         # Overrides/align yarnrc.yml options (v3, v4) for a CI context
-        YARN_ENABLE_GLOBAL_CACHE: 'false' # Use local cache folder to keep downloaded archives
-        YARN_NM_MODE: 'hardlinks-local' # Reduce node_modules size
+        YARN_ENABLE_GLOBAL_CACHE: 'false'  # Use local cache folder to keep downloaded archives
+        YARN_ENABLE_MIRROR: 'false'        # Prevent populating global cache for caches misses (local cache only)
+        YARN_NM_MODE: 'hardlinks-local'    # Reduce node_modules size
         YARN_INSTALL_STATE_PATH: '.yarn/ci-cache/install-state.gz' # Might speed up resolution step when node_modules present
         # Other environment variables
         HUSKY: '0' # By default do not run HUSKY install
-

--- a/.github/workflows/ci-install-benchmark.yml
+++ b/.github/workflows/ci-install-benchmark.yml
@@ -76,6 +76,7 @@ jobs:
         env:
           YARN_RC_FILENAME: .yarnrc.mixed-compress.yml
           YARN_ENABLE_GLOBAL_CACHE: 'false'
+          YARN_ENABLE_MIRROR: 'false'
           YARN_CACHE_FOLDER: .yarn/benchmark-cache/mixed-compress
           YARN_INSTALL_STATE_PATH: .yarn/install-state-mixed-compress.gz
 
@@ -87,6 +88,7 @@ jobs:
         env:
           YARN_RC_FILENAME: '.yarnrc.no-compress.yml'
           YARN_ENABLE_GLOBAL_CACHE: 'false'
+          YARN_ENABLE_MIRROR: 'false'
           YARN_CACHE_FOLDER: '.yarn/benchmark-cache/pnp-no-compress'
           YARN_INSTALL_STATE_PATH: .yarn/install-state-no-compress.gz
 
@@ -98,6 +100,7 @@ jobs:
         env:
           YARN_RC_FILENAME: '.yarnrc.mixed-compress.yml'
           YARN_ENABLE_GLOBAL_CACHE: 'false'
+          YARN_ENABLE_MIRROR: 'false'
           YARN_CACHE_FOLDER: '.yarn/benchmark-cache/no-compress'
           YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache.gz
 
@@ -109,6 +112,7 @@ jobs:
         env:
           YARN_RC_FILENAME: '.yarnrc.no-compress.yml'
           YARN_ENABLE_GLOBAL_CACHE: 'false'
+          YARN_ENABLE_MIRROR: 'false'
           YARN_CACHE_FOLDER: '.yarn/benchmark-cache/no-cache-no-comp'
           YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache-no-compress.gz
 
@@ -140,6 +144,7 @@ jobs:
         continue-on-error: true
         env:
           YARN_ENABLE_GLOBAL_CACHE: 'false'
+          YARN_ENABLE_MIRROR: 'false'
           YARN_NODE_LINKER: 'pnp'
           YARN_NM_MODE: 'hardlinks-local'
           YARN_CACHE_FOLDER: '.yarn/benchmark-pnp-cache/no-compress'

--- a/.github/workflows/ci-install-benchmark.yml
+++ b/.github/workflows/ci-install-benchmark.yml
@@ -107,7 +107,7 @@ jobs:
       - name: 🧹 Remove node_modules
         run: npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
 
-      - name: 📥 Yarn install no-cache (no-compress)
+      - name: 📥 Yarn install no-cache (no-compress) - NO MIRROR
         run: yarn install --immutable --inline-builds
         env:
           YARN_RC_FILENAME: '.yarnrc.no-compress.yml'
@@ -115,6 +115,16 @@ jobs:
           YARN_ENABLE_MIRROR: 'false'
           YARN_CACHE_FOLDER: '.yarn/benchmark-cache/no-cache-no-comp'
           YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache-no-compress.gz
+
+      - name: 📥 Yarn install no-cache (no-compress) - WITH MIRROR
+        run: yarn install --immutable --inline-builds
+        env:
+          YARN_RC_FILENAME: '.yarnrc.no-compress.yml'
+          YARN_ENABLE_GLOBAL_CACHE: 'false'
+          YARN_ENABLE_MIRROR: 'true'
+          YARN_CACHE_FOLDER: '.yarn/benchmark-cache/no-cache-no-comp-mirror'
+          YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache-no-compress-mirror.gz
+
 
       - name: 🧹 Remove node_modules
         run: npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"

--- a/.github/workflows/ci-install-benchmark.yml
+++ b/.github/workflows/ci-install-benchmark.yml
@@ -80,8 +80,11 @@ jobs:
           YARN_CACHE_FOLDER: .yarn/benchmark-cache/mixed-compress
           YARN_INSTALL_STATE_PATH: .yarn/install-state-mixed-compress.gz
 
-      - name: 🧹 Remove node_modules
-        run: npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+      - name: 🧹 Cleanup workspace
+        run: |
+          npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+          yarn cache clean --all
+          npm cache clean --force
 
       - name: 📥 Yarn install dependencies (no-compress)
         run: yarn install --immutable --inline-builds
@@ -92,10 +95,13 @@ jobs:
           YARN_CACHE_FOLDER: '.yarn/benchmark-cache/pnp-no-compress'
           YARN_INSTALL_STATE_PATH: .yarn/install-state-no-compress.gz
 
-      - name: 🧹 Remove node_modules
-        run: npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+      - name: 🧹 Cleanup workspace
+        run: |
+          npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+          yarn cache clean --all
+          npm cache clean --force
 
-      - name: 📥 Yarn install no-cache (mixed-compress)
+      - name: 📥 Yarn install cache (mixed-compress)
         run: yarn install --immutable --inline-builds
         env:
           YARN_RC_FILENAME: '.yarnrc.mixed-compress.yml'
@@ -104,10 +110,13 @@ jobs:
           YARN_CACHE_FOLDER: '.yarn/benchmark-cache/no-compress'
           YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache.gz
 
-      - name: 🧹 Remove node_modules
-        run: npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+      - name: 🧹 Cleanup workspace
+        run: |
+          npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+          yarn cache clean --all
+          npm cache clean --force
 
-      - name: 📥 Yarn install no-cache (no-compress) - NO MIRROR
+      - name: 📥 Yarn install no-cache (no-compress)
         run: yarn install --immutable --inline-builds
         env:
           YARN_RC_FILENAME: '.yarnrc.no-compress.yml'
@@ -116,29 +125,32 @@ jobs:
           YARN_CACHE_FOLDER: '.yarn/benchmark-cache/no-cache-no-comp'
           YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache-no-compress.gz
 
-      - name: 📥 Yarn install no-cache (no-compress) - WITH MIRROR
-        run: yarn install --immutable --inline-builds
-        env:
-          YARN_RC_FILENAME: '.yarnrc.no-compress.yml'
-          YARN_ENABLE_GLOBAL_CACHE: 'false'
-          YARN_ENABLE_MIRROR: 'true'
-          YARN_CACHE_FOLDER: '.yarn/benchmark-cache/no-cache-no-comp-mirror'
-          YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache-no-compress-mirror.gz
-
-
-      - name: 🧹 Remove node_modules
-        run: npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+      - name: 🧹 Cleanup workspace
+        run: |
+          npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+          yarn cache clean --all
+          npm cache clean --force
 
       - name: 📥 PNPM install
         shell: bash
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: 🧹 Remove node_modules
-        run: npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+      - name: 🧹 Cleanup workspace
+        run: |
+          npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+          yarn cache clean --all
+          npm cache clean --force
 
       - name: 📥 PNPM install no-cache
         shell: bash
         run: pnpm install --store-dir ./node_modules/.pnpm-global-store --frozen-lockfile --prefer-offline
+
+
+      - name: 🧹 Cleanup workspace
+        run: |
+          npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+          yarn cache clean --all
+          npm cache clean --force
 
       - name: ♻ Setup yarn pnp cache (no-compress)
         uses: actions/cache@v3

--- a/.github/workflows/ci-yarn-no-mirror.yml
+++ b/.github/workflows/ci-yarn-no-mirror.yml
@@ -1,5 +1,5 @@
 # Bench yarn with compression vs without + action/cache
-name: 'Install benchmarks'
+name: 'Yarn enable mirror comparison'
 on: [push]
 
 env:
@@ -37,7 +37,7 @@ jobs:
           YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache-no-compress-warmup.gz
 
 
-      - name: 🧹 cleanup space
+      - name: 🧹 Cleanup workspace
         run: | 
           npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
           yarn cache clean --all

--- a/.github/workflows/ci-yarn-no-mirror.yml
+++ b/.github/workflows/ci-yarn-no-mirror.yml
@@ -1,0 +1,70 @@
+# Bench yarn with compression vs without + action/cache
+name: 'Install benchmarks'
+on: [push]
+
+env:
+  PRISMA_SKIP_POSTINSTALL_GENERATE: 'true'
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 'true'
+  HUSKY: '0'
+
+jobs:
+  install-bench:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # not needed outside benchmarks
+      - name: ⚙ To ease benchmarks and detection of YARN_RC_FILENAME
+        run: corepack enable
+
+
+      - name: 📥 PRE-WARM (some native binaries might have been cached)
+        run: yarn install --immutable --inline-builds
+        env:
+          YARN_RC_FILENAME: '.yarnrc.no-compress.yml'
+          YARN_ENABLE_GLOBAL_CACHE: 'false'
+          YARN_ENABLE_MIRROR: 'false'
+          YARN_CACHE_FOLDER: '.yarn/benchmark-cache/no-cache-no-comp-warmup'
+          YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache-no-compress-warmup.gz
+
+
+      - name: 🧹 cleanup space
+        run: | 
+          npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+          yarn cache clean --all
+          npm cache clean --force
+
+      - name: 📥 Yarn install no-cache (no-compress) - NO MIRROR
+        run: yarn install --immutable --inline-builds
+        env:
+          YARN_RC_FILENAME: '.yarnrc.no-compress.yml'
+          YARN_ENABLE_GLOBAL_CACHE: 'false'
+          YARN_ENABLE_MIRROR: 'false'
+          YARN_CACHE_FOLDER: '.yarn/benchmark-cache/no-cache-no-comp'
+          YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache-no-compress.gz
+
+      - name: 🧹 cleanup space
+        run: |
+          npx -y rimraf@5.0.1 --glob "**/node_modules" ".yarn/install-state*.gz"
+          yarn cache clean --all
+          npm cache clean --force
+
+      - name: 📥 Yarn install no-cache (no-compress) - WITH MIRROR
+        run: yarn install --immutable --inline-builds
+        env:
+          YARN_RC_FILENAME: '.yarnrc.no-compress.yml'
+          YARN_ENABLE_GLOBAL_CACHE: 'false'
+          YARN_ENABLE_MIRROR: 'true'
+          YARN_CACHE_FOLDER: '.yarn/benchmark-cache/no-cache-no-comp-mirror'
+          YARN_INSTALL_STATE_PATH: .yarn/install-state-no-cache-no-compress-mirror.gz
+
+


### PR DESCRIPTION
Follow up of: 

https://github.com/yarnpkg/berry/issues/5569

Just testing the impact of `enableMirror: false` on CI. (compression and enableGlobalCache disabled)

| enableMirror |Time  |
|--------------|--------------|
| enabled (default) | +/-53s |
| disabled              | +/-45s |

Expect more if compression is enabled (mxed)

![image](https://github.com/belgattitude/compare-package-managers/assets/259798/eb2058c2-fda3-4f89-bb8a-430f498e2f86)


